### PR TITLE
Replace PhantomJS with Puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "problems",
     "pdf",
     "export",
-    "phantom"
+    "puppeteer"
   ],
   "author": "Alex Valencia <alex.valencia@me.com> (http://www.avocadodesigns.net)",
   "license": "MIT",
@@ -33,6 +33,6 @@
     "chalk": "^1.1.3",
     "github": "^9.2.0",
     "inquirer": "^3.0.6",
-    "phantom": "^4.0.2"
+    "puppeteer": "^1.9.0"
   }
 }


### PR DESCRIPTION
Addresses: https://github.com/alexandervalencia/github-issues-to-pdf/issues/12

Replaces the use of PhantomJS with Puppeteer. The other change was to create the directory to save PDFs to, this isn't done automatically by Puppeteer. 

I tested locally with a number of different users/organisations and results were 👌 